### PR TITLE
More adaptions for ops; support benchmark for blas and norm ops

### DIFF
--- a/CPUPorting.md
+++ b/CPUPorting.md
@@ -6,23 +6,26 @@
 
   - [x] attension_ops
   - [ ] binary_pointwise_ops
-    - [ ] clamp, nan_to_num算子：精度不够。
+    - [ ] clamp, nan_to_num算子：精度不足
     - [ ] `where` related ops：`AssertionError: CPU only. There seems a mistake to dispatch to here.`
+    - [x] `floor_divide`，`remainder`相关测试报错：`Floating point exception`。
+      该报错与Triton的对0取余行为有关。
+    - [ ] `remainder`相关测试精度不足
   - [x] blas_ops
   - [x] distribution_ops
   - [x] general_reduction_ops
   - [x] libentry
   - [ ] norm_ops
-    - [ ] 待添加
-  - [ ] pointwise_dynamic
-    - [ ] `floor_divide`，`remainder`相关测试报错：`Floating point exception`。已设置跳过测试。
+    - [ ] `batch_norm`：精度不足
+  - [x] pointwise_dynamic
   - [ ] pointwise_dynamic_type_promotion
     - [ ] `where` related ops：`AssertionError: CPU only. There seems a mistake to dispatch to here.`
   - [ ] reduction_ops
+    - [ ] `batch_norm`：精度不足
     - [ ] 待添加
   - [x] shape_utils
   - [ ] special_ops
-    - [ ] 待添加
+    - [ ] 精度不足: `pad`, `kron`
   - [x] tensor_constructor
     该测试中的`test_accuracy_randn`小概率出现精度不够的问题
   - [x] tensor_wrapper
@@ -34,21 +37,21 @@
 ## TODO
 
 - [ ] 浮点精度问题：现在的triton-cpu应该只支持float和double精度的计算，目前FlagGems中的精度相关代码，如测试函数，尚未被修改。
-- [ ] 并行：即使设置`TRITON_CPU_MAX_THREADS=0`，`pytest test_xxx.py`也无法并行运行算子？
+- [ ] 并行：即使设置`TRITON_CPU_MAX_THREADS=0`，`pytest test_xxx.py`也无法并行运行算子。
 - [ ] `Philox API`：对于`distribution ops`，采用了很多`cuda philox`，目前只采用了最简单的处理。
   相关函数：multinomial, randperm, rand_like, rand, randn, randn_like
 - [ ] `libtuner`：`mm`算子采用`libtuner`，但是会报错。替换成`triton.autotuner`才能正常运行。
 - [ ] `benchmark`运行时间过长，调整测试规模。
-- [ ] 改进`batch_norm`算子，当前算法下无法通过`test_reduction_ops`下的`test_accuracy_batch_norm`测试
 - [ ] 移除分布在几十个文件中多余的`torch_device_fn`，该变量使用场景相当局限和单一，可以考虑将该全局变量优化掉。
 - [ ] 目前有几个测试的测试时间过长，即使设置`--mode=quick`，也需要至少十几分钟，甚至半小时，不利于正确性验证，考虑缩减测试规模或优化CPU上的相关算子。
   - [x] test_attension_ops
   - [ ] test_tensor_constructor
-  - [ ] test_norm_ops
-  - [ ] test_reduction_ops
+  - [ ] test_reduction_ops: 算子`conv`运行时间过长
+  - [ ] test_special_ops: 算子`sort`, `upsample`运行时间过长
   - [ ] 待添加
 - [ ] 优化`multinomial`算子。注：该算子存在改动且确定存在需要对CPU端进行更大的、进一步的优化，因此已将其放在cpu后端的算子目录中。
 - [ ] 重新实现`where`算子，FlagGems的`where`算子实现不能用CPU跑。
+- [ ] 目前对于`div`算子文件中`__remainder`函数的处理方式不一定正确，后续需要确定其正确性。同时`floordiv`相关函数也需要关注。
 
 ## 大致修改
 

--- a/CPUPorting.md
+++ b/CPUPorting.md
@@ -2,6 +2,11 @@
 
 ## 进展
 
+- benchmarks:
+  
+  - [x] blas
+  - [x] norm
+
 - tests: 大多数测试都能跑通，现有问题在下面的`TODO`中说明
 
   - [x] attension_ops

--- a/README.md
+++ b/README.md
@@ -45,11 +45,9 @@ print(C2)
 2. Benchmark single operator performance. Take `mm` and `layer_norm` for example:
 ```shell
 cd benchmark
-time pytest test_blas_perf.py -s --mode cpu --record log --level core --dtypes float32 --warmup 25 --iter 100 -m mm
-time pytest test_norm_perf.py -s --mode cpu --record log --level core --dtypes float32 --warmup 25 --iter 100 -m layer_norm
+time pytest test_blas_perf.py -s --record log --level core --dtypes float32 --warmup 25 --iter 100 -m mm
+time pytest test_norm_perf.py -s --record log --level core --dtypes float32 --warmup 25 --iter 100 -m layer_norm
 ```
-> FIXME: Resolve the error when running scripts in the benchmark directory due to `performance_utils.py` being incompatible with CPU. Specifically, the line with "torch_backend_device.matmul.allow_tf32 = False" fails with: "AttributeError: module 'torch.backends.cpu' has no attribute 'matmul'".
-
 
 3. Benchmark all ops performance. You can modify `run_all_perf_tests.sh` to test the ops you want.
 ```shell

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -196,13 +196,13 @@ def setup_once(request):
     #     print(note_info)
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(scope="function", autouse=flag_gems.device != "cpu")
 def clear_function_cache():
     yield
     torch_device_fn.empty_cache()
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module", autouse=flag_gems.device != "cpu")
 def clear_module_cache():
     yield
     torch_device_fn.empty_cache()

--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -34,6 +34,8 @@ device = flag_gems.device
 vendor_name = flag_gems.vendor_name
 if device == "musa":
     torch.backends.mudnn.allow_tf32 = False
+elif device == "cpu":
+    pass
 else:
     torch_backend_device.matmul.allow_tf32 = False
 

--- a/benchmark/run_all_perf_tests.sh
+++ b/benchmark/run_all_perf_tests.sh
@@ -20,7 +20,6 @@ for name in "${benchmark_names[@]}"; do
     {
         echo "Running test: $name with 16 threads"
         time pytest "test_${name}_perf.py" -s \
-            --mode cpu \
             --record log \
             --level core \
             --dtypes float32 \

--- a/src/flag_gems/ops/pad.py
+++ b/src/flag_gems/ops/pad.py
@@ -68,7 +68,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from triton import language as tl")
     code.newline()
     code.writeline("from flag_gems.utils.libentry import libentry")
-    code.writeline("from flag_gems.runtime import torch_device_fn")
+    code.writeline("from flag_gems.runtime import torch_device_fn, get_torch_device_ctx")
     code.writeline("from flag_gems.utils import triton_lang_extension as tle")
     code.writeline("from flag_gems.utils.type_utils import type_promotion")
     code.newline()

--- a/tests/accuracy_utils.py
+++ b/tests/accuracy_utils.py
@@ -57,7 +57,7 @@ sizes_2d_nr = [1] if QUICK_MODE else [1, 5, 1024]
 UT_SHAPES_1D = list((n,) for n in sizes_1d)
 UT_SHAPES_2D = list(itertools.product(sizes_2d_nr, sizes_2d_nc))
 POINTWISE_SHAPES = (
-    [(2, 19, 7)]
+    [(2, 19)]
     if QUICK_MODE
     else [(), (1,), (1024, 1024), (20, 320, 15), (16, 128, 64, 60), (16, 7, 57, 32, 29)]
 )
@@ -71,7 +71,7 @@ REDUCTION_SHAPES = [(2, 32)] if QUICK_MODE else [(1, 2), (4096, 256), (200, 4099
 REDUCTION_SMALL_SHAPES = (
     [(1, 32)] if QUICK_MODE else [(1, 2), (4096, 256), (200, 2560, 3)]
 )
-STACK_SHAPES = [
+STACK_SHAPES = [[(4,), (4,)]] if QUICK_MODE else [
     [(16,), (16,)],
     [(16, 256), (16, 256)],
     [(20, 320, 15), (20, 320, 15), (20, 320, 15)],
@@ -122,7 +122,7 @@ UPSAMPLE_SHAPES = [
 ]
 
 
-KRON_SHAPES = [
+KRON_SHAPES = [[(), (2, 3)]] if QUICK_MODE else [
     [(), (2, 3)],
     [(2, 3), ()],
     [(0, 3), (2, 3)],

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -23,7 +23,7 @@ from .accuracy_utils import (
     gems_assert_equal,
     to_reference,
 )
-from .conftest import TO_CPU
+from .conftest import QUICK_MODE, TO_CPU
 
 device = flag_gems.device
 
@@ -478,6 +478,7 @@ def test_pad(shape, dtype, pad_mode, contiguous):
     gems_assert_equal(res_out, ref_out)
 
 
+@pytest.mark.skipif(flag_gems.device == "cpu", reason="Consuming a significant time")
 @pytest.mark.skipif(flag_gems.vendor_name == "cambricon", reason="fix")
 @pytest.mark.skipif(flag_gems.device == "musa", reason="torch not supports half yet")
 @pytest.mark.upsample_bicubic2d_aa
@@ -518,6 +519,7 @@ def test_upsample_bicubic2d_aa(dtype, shape, scale, align_corners):
     gems_assert_close(res_out, ref_out, dtype, reduce_dim=reduce_dim)
 
 
+@pytest.mark.skipif(flag_gems.device == "cpu", reason="Consuming a significant time")
 @pytest.mark.upsample_nearest2d
 @pytest.mark.parametrize("scale", [(2, 2), (2.1, 3.7), (1.3, 5.1), (0.3, 0.5)])
 @pytest.mark.parametrize("shape", UPSAMPLE_SHAPES)
@@ -757,7 +759,7 @@ def test_exception_hstack(shape, dtype):
             _ = torch.hstack(inp)
 
 
-CAT_SHAPES = [
+CAT_SHAPES = [[(1, 32), (8, 32)]] if QUICK_MODE else [
     [(1, 32), (8, 32)],
     [(16, 128), (32, 128)],
     [(1024, 1024), (1024, 1024)],
@@ -832,7 +834,7 @@ def test_accuracy_cat_empty_tensor(shape, dim, dtype):
     gems_assert_equal(res_out, ref_out)
 
 
-VSTACK_SHAPES = [
+VSTACK_SHAPES = [[(2,), (2,)]] if QUICK_MODE else [
     [(3,), (3,)],
     [(3, 33), (7, 33)],
     [(13, 3, 333), (17, 3, 333), (7, 3, 333)],
@@ -860,6 +862,7 @@ VSTACK_SHAPES_TEST = VSTACK_SHAPES + (
 )
 
 
+@pytest.mark.skipif(flag_gems.device == "cpu", reason="Too time-consuming")
 @pytest.mark.vstack
 @pytest.mark.parametrize("shape", VSTACK_SHAPES_TEST)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES + INT_DTYPES)
@@ -881,7 +884,7 @@ def test_accuracy_vstack(shape, dtype):
     gems_assert_equal(res_out, ref_out)
 
 
-REPEAT_INTERLEAVE_SHAPES = [
+REPEAT_INTERLEAVE_SHAPES = [(1024, 1024)] if QUICK_MODE else [
     (1024, 1024),
     (20, 320, 15),
     (16, 128, 64, 60),
@@ -1061,7 +1064,7 @@ def test_accuracy_diagonal_backward(shape, dtype, dim1, dim2, offset):
 @pytest.mark.skipif(flag_gems.vendor_name == "kunlunxin", reason="RESULT TODOFIX")
 @pytest.mark.sort
 @pytest.mark.parametrize("batch_size", [4, 8])
-@pytest.mark.parametrize("hiddensize", [1, 256, 2048, 9333, 65536])
+@pytest.mark.parametrize("hiddensize", [256] if QUICK_MODE else [1, 256, 2048, 9333, 65536])
 @pytest.mark.parametrize("descending", [True, False])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES + INT_DTYPES)
 @pytest.mark.parametrize("dim", [0, -1])


### PR DESCRIPTION
The most important: The flag `--mode cpu` of pytest in FlagGems means running with native torch method, so just remove it.

By the way, the flags about parallelism in `run_all_test_perf.sh` seem to be meaningless. I executed this in my command line: `time pytest test_blas_perf.py -s --record log --level core --dtypes float32 --warmup 10 --iter 20`, then I got:
![image](https://github.com/user-attachments/assets/472a392c-6d5f-460a-b8da-9e9c20501107)
I ran the shell file and got:
![image](https://github.com/user-attachments/assets/a033579c-3c22-45dc-ae0d-aaf9f60287f0)
They are basically the same.