### PR TITLE
Optimize the performance of six operators.

### DIFF
--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -371,7 +371,7 @@ class LayerNorm(torch.autograd.Function):
                     TILE_N,
                 )
             elif N <= 4096:
-                TILE_N = triton.next_power_of_2(N)
+               # TILE_N = triton.next_power_of_2(N)
                 grid = (M, 1, 1)
                 layer_norm_persistent_kernel[grid](
                     x,
@@ -383,7 +383,7 @@ class LayerNorm(torch.autograd.Function):
                     M,
                     N,
                     eps,
-                    TILE_N,
+                #    TILE_N,
                 )
             else:
                 grid = (M, 1, 1)

--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -11,7 +11,11 @@ from ..utils import triton_lang_extension as tle
 
 
 @libentry()
-@triton.heuristics(runtime.get_heuristic_config("softmax_non_inner"))
+#@triton.heuristics(runtime.get_heuristic_config("softmax_non_inner"))
+@triton.autotune(
+    configs=runtime.get_tuned_config("softmax_non_inner"),
+    key=["M", "N", "K"],
+)
 @triton.jit
 def softmax_kernel_non_inner(
     output_ptr,
@@ -83,7 +87,11 @@ def prev_multiple_of(a, b):
 
 
 @libentry()
-@triton.heuristics(runtime.get_heuristic_config("softmax_inner"))
+#@triton.heuristics(runtime.get_heuristic_config("softmax_inner"))
+@triton.autotune(
+    configs=runtime.get_tuned_config("softmax_inner"),
+    key=["M", "N"],
+)
 @triton.jit
 def softmax_kernel_inner(
     output_ptr,

--- a/src/flag_gems/runtime/backend/_arm/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_arm/tune_configs.yaml
@@ -23,12 +23,26 @@ attention:
   - 3
 bmm:
 - META:
-    TILE_M: 4
-    TILE_N: 4
-    TILE_K: 4
     GROUP_M: 1
-  num_warps: 4
+    TILE_K: 4
+    TILE_M: 16
+    TILE_N: 16
   num_stages: 2
+  num_warps: 4
+- META:
+    GROUP_M: 1
+    TILE_K: 8
+    TILE_M: 4
+    TILE_N: 16
+  num_stages: 2
+  num_warps: 4
+- META:
+    GROUP_M: 1
+    TILE_K: 8
+    TILE_M: 8
+    TILE_N: 16
+  num_stages: 2
+  num_warps: 4
 argmax:
 - META:
     BLOCK_M: 8
@@ -56,25 +70,57 @@ log_softmax:
   num_warps: 4
 mm:
 - META:
-    BLOCK_M: 4
-    BLOCK_N: 4
     BLOCK_K: 4
+    BLOCK_M: 16
+    BLOCK_N: 16
     SPLIT_K: 1
   num_stages: 4
   num_warps: 4
 - META:
-    BLOCK_M: 8
-    BLOCK_N: 8
     BLOCK_K: 8
+    BLOCK_M: 4
+    BLOCK_N: 16
+    SPLIT_K: 1
+  num_stages: 4
+  num_warps: 4
+- META:
+    BLOCK_K: 8
+    BLOCK_M: 8
+    BLOCK_N: 16
     SPLIT_K: 1
   num_stages: 4
   num_warps: 4
 softmax_non_inner:
-- META:
-    TILE_K: 4
+  - gen: true
+    param_map:
+      META:
+        TILE_N: tile_n
+        TILE_K: tile_k
+        ONE_TILE_PER_CTA: False
+      num_warps: 4
+      num_stages: 4
+    tile_n:
+      - 2
+      - 4
+    tile_k:
+      - 8
+      - 64
 softmax_inner:
 - META:
-    TILE_N: 4
+    TILE_N: 16
+    ONE_TILE_PER_CTA: False
+  num_stages: 4
+  num_warps: 4
+- META:
+    TILE_N: 32
+    ONE_TILE_PER_CTA: False
+  num_stages: 4
+  num_warps: 4
+- META:
+    TILE_N: 64
+    ONE_TILE_PER_CTA: False
+  num_stages: 4
+  num_warps: 4
 test_libentry:
 - META:
     TILE_N: 32
@@ -223,12 +269,15 @@ index_select:
 layer_norm_persistent:
 - gen: true
   param_map:
-    META: {}
+    META:
+      TILE_N: tile_n
     num_warps: warps
-  warps:
-  - 4
+  tile_n:
+  - 2
   - 8
   - 16
+  warps:
+  - 4
 layer_norm_loop:
 - gen: true
   param_map:
@@ -414,19 +463,12 @@ mv:
     num_stages: stages
   warps:
   - 4
-  - 8
   block_m:
   - 32
-  - 64
-  - 128
   block_n:
-  - 1
-  - 2
-  - 4
   - 8
   stages:
   - 3
-  - 4
 nonzero:
 - gen: true
   param_map:
@@ -853,15 +895,16 @@ conv2d_backward_weight:
 batch_norm:
 - gen: true
   param_map:
-    META: {}
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: block_n
     num_warps: warps
+  block_m:
+    - 64
+  block_n:
+    - 256
   warps:
-  - 1
-  - 2
-  - 4
-  - 8
-  - 16
-  - 32
+    - 4
 index_put:
 - gen: true
   param_map:


### PR DESCRIPTION
Optimized the performance of the mm, layernorm, bmm, mv, batchnorm, and softmax operators on the AVX512 CPU platform. 

Main changes：

1. In FlagGems-CPU/src/flag_gems/runtime/backend/_arm/tune_configs.yaml：

- the auto-tuning parameter ranges for the six operators were adjusted.

2.  In FlagGems-CPU/src/flag_gems/ops/layernorm.py and FlagGems-CPU/src/flag_gems/ops/softmax.py：

-  the tuning methods for the operators were modified.

Command Execution Steps (Taking mm as an Example):

1. **Performance before tuning adjustment:**  
   ```bash
   cd benchmark
   time pytest test_blas_perf.py -s --record log --level core --dtypes float32 --warmup 25 --iter 100 -m mm
   ```

2. **Performance after tuning adjustment:**  
   ```bash
   time pytest test_blas_perf.py -s --record log --level core --dtypes float32 --warmup 25 --iter 100 -m mm --log-file=blas_perf_mm_modify
   ```

3. **Compare performance changes before and after parameter adjustment:**  
   ```bash
   python summary_for_plot.py result_test_blas_perf-s--record_log--level_core--dtypes_float32--warmup_25--iter_100-m_mm--log-file_blas_perf_mm_modify.log -c result_test_blas_perf-s--record_log--level_core--dtypes_float32--warmup_25--iter_100-m_mm.log
   ```

4. **View the comparison results:**  
   ```bash
   vim result_test_compare.log
   ```
 Performance ：
The performance improvement ratios for the operators range from 1.11 to 4.04.
![image](https://github.com/user-attachments/assets/da314c90-ae38-46cb-8f5c-3d37d60cb7d4)
![image](https://github.com/user-attachments/assets/c967ff30-a366-4272-a037-272d4c657dcb)
![image](https://github.com/user-attachments/assets/9568f83c-1580-42ee-9c29-7ff4fda54288)
![image](https://github.com/user-attachments/assets/30ae6d1a-503b-47ba-961d-6ea5e995407c)
![image](https://github.com/user-attachments/assets/8071649d-806f-41e7-9d77-03dd52240dbf)
![image](https://github.com/user-attachments/assets/89b852e7-e7ed-499a-97a2-4ce8cea29729)

